### PR TITLE
Fix build on ubuntu 20.04

### DIFF
--- a/h264dec.cpp
+++ b/h264dec.cpp
@@ -85,7 +85,7 @@ enum
   PROP_OOB_PIC_PARAMS,
 };
 
-G_DEFINE_FINAL_TYPE(GstH264Dec, gst_h264_dec, GST_TYPE_H264_DECODER)
+G_DEFINE_TYPE(GstH264Dec, gst_h264_dec, GST_TYPE_H264_DECODER)
 
 static gpointer parent_class = NULL;
 

--- a/h265dec.cpp
+++ b/h265dec.cpp
@@ -86,7 +86,7 @@ enum
   PROP_OOB_PIC_PARAMS,
 };
 
-G_DEFINE_FINAL_TYPE(GstH265Dec, gst_h265_dec, GST_TYPE_H265_DECODER)
+G_DEFINE_TYPE(GstH265Dec, gst_h265_dec, GST_TYPE_H265_DECODER)
 
 static gpointer parent_class = NULL;
 

--- a/h265dec.cpp
+++ b/h265dec.cpp
@@ -334,7 +334,7 @@ fill_sps(GstH265SPS* sps, VkH265Picture* vkp)
             .sps_palette_predictor_initializer_present_flag = sps->sps_scc_extension_params.sps_palette_predictor_initializers_present_flag,
             .intra_boundary_filtering_disabled_flag = sps->sps_scc_extension_params.intra_boundary_filtering_disabled_flag,
         },
-        .profile_idc = get_profile_idc(sps->profile_tier_level.profile_idc),
+        .profile_idc = get_profile_idc(static_cast<GstH265ProfileIDC>(sps->profile_tier_level.profile_idc)),
         .level_idc = static_cast<StdVideoH265Level>(sps->profile_tier_level.level_idc),
         .pic_width_in_luma_samples = sps->pic_width_in_luma_samples,
         .pic_height_in_luma_samples = sps->pic_height_in_luma_samples,
@@ -379,7 +379,7 @@ fill_pps (GstH265PPS * pps, VkH265Picture * vkp)
 }
 
 static void
-fill_vps (GstH265VS * vps, VkH265Picture * vkp)
+fill_vps (GstH265VPS * vps, VkH265Picture * vkp)
 {
 }
 
@@ -460,8 +460,8 @@ gst_h265_dec_start_picture (GstH265Decoder * decoder, GstH265Picture * picture,
       // // 0 = invalid, 1 = Main, 2 = Main10, 3 = still picture, 4 = Main 12,
       // // 5 = MV-HEVC Main8
       .ProfileLevel = vps->profile_tier_level.profile_idc,
-      .ColorPrimaries = (sps->vui_parameters_present_flag ? sps->vui_params.colour_primaries : 0), // ColorPrimariesBTXXXX enum
-      .bit_depth_luma_minus8 = (pps->pps_scc_extension_flag ? pps->pps_scc_extension_params.luma_bit_depth_entry_minus8 : 0),
+      .ColorPrimaries = (sps->vui_parameters_present_flag ? sps->vui_params.colour_primaries : (uint8_t)0), // ColorPrimariesBTXXXX enum
+      .bit_depth_luma_minus8 = (pps->pps_scc_extension_flag ? pps->pps_scc_extension_params.luma_bit_depth_entry_minus8 : (uint8_t)0),
       .bit_depth_chroma_minus8 = (pps->pps_scc_extension_flag ? pps->pps_scc_extension_params.chroma_bit_depth_entry_minus8 : 0),
 
       // // MV-HEVC related fields
@@ -565,7 +565,7 @@ gst_h265_dec_update_picture_parameters (GstH265Decoder * decoder,
       // if (pps_cmp (&self->last_pps, pps))
       //   return;
       // self->last_pps = *pps;
-      // fill_pps (pps, &self->vkp);
+      // fill_vps (pps, &self->vkp);
       params = (VkPictureParameters) {
         .updateType = VK_PICTURE_PARAMETERS_UPDATE_H265_VPS,
         .pH265Vps = &self->vkp.vps,

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('gst-vkvideo-parser', 'c', 'cpp',
-  default_options : [ 'warning_level=1', 'buildtype=debug' ]
+  default_options : [ 'warning_level=1', 'buildtype=debug', 'cpp_std=c++17' ]
 )
 
 sources = [

--- a/pipeline.c
+++ b/pipeline.c
@@ -41,7 +41,7 @@ enum
 GST_DEBUG_CATEGORY (gst_video_parser_debug);
 #define GST_CAT_DEFAULT gst_video_parser_debug
 
-G_DEFINE_FINAL_TYPE_WITH_CODE (GstVideoParser, gst_video_parser,
+G_DEFINE_TYPE_WITH_CODE (GstVideoParser, gst_video_parser,
     GST_TYPE_OBJECT, GST_DEBUG_CATEGORY_INIT (gst_video_parser_debug,
         "videoparser", 0, "Video Parser"))
 


### PR DESCRIPTION
- The bundled glib version does not support G_DEFINE_FINAL_TYPE use of G_DEFINE_TYPE instead
- Ubuntu 20.04 ships with g++ 9.4.0, needs to define c++17 as the minimum version to build with vector and atomic in Picture
```
In file included from /usr/include/c++/9/vector:66,
                 from ../test.cpp:23:
/usr/include/c++/9/bits/stl_uninitialized.h: In instantiation of ‘_ForwardIterator std::uninitialized_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<const Picture*, std::vector<Picture> >; _ForwardIterator = Picture*]’:
/usr/include/c++/9/bits/stl_uninitialized.h:307:37:   required from ‘_ForwardIterator std::__uninitialized_copy_a(_InputIterator, _InputIterator, _ForwardIterator, std::allocator<_Tp>&) [with _InputIterator = __gnu_cxx::__normal_iterator<const Picture*, std::vector<Picture> >; _ForwardIterator = Picture*; _Tp = Picture]’
/usr/include/c++/9/bits/stl_vector.h:555:31:   required from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Picture; _Alloc = std::allocator<Picture>]’
../test.cpp:96:7:   required from here
/usr/include/c++/9/bits/stl_uninitialized.h:127:72: error: static assertion failed: result type must be constructible from value type of input range
  127 |       static_assert(is_constructible<_ValueType2, decltype(*__first)>::value,
```
h265dec: fix build with bad variable names.